### PR TITLE
Ruby 1.9 compatibility

### DIFF
--- a/lib/keydown/lib/slide.rb
+++ b/lib/keydown/lib/slide.rb
@@ -114,7 +114,7 @@ module Keydown
       @codemap.each do |id, code_block|
         lang = code_block[:lang]
         code = code_block[:code]
-        if code.all? { |line| line =~ /\A\r?\n\Z/ || line =~ /^(  |\t)/ }
+        if code.lines.all? { |line| line =~ /\A\r?\n\Z/ || line =~ /^(  |\t)/ }
           code.gsub!(/^(  |\t)/m, '')
         end
 

--- a/spec/tasks/generate_spec.rb
+++ b/spec/tasks/generate_spec.rb
@@ -13,7 +13,7 @@ describe Keydown do
     before :each do
       capture_output do
         Dir.chdir @tmp_dir do
-          @thor.invoke Keydown::Tasks, "generate", "sample"
+          @thor.invoke Keydown::Tasks, ["generate", "sample"]
         end
       end
     end

--- a/spec/tasks/slides_spec.rb
+++ b/spec/tasks/slides_spec.rb
@@ -38,7 +38,7 @@ describe Keydown, "`slides`" do
     before(:each) do
       Dir.chdir @tmp_dir do
         @std_out = capture_output do
-          @thor.invoke Keydown::Tasks, "slides", "with_title.md"
+          @thor.invoke Keydown::Tasks, ["slides", "with_title.md"]
         end
       end
     end
@@ -63,7 +63,7 @@ describe Keydown, "`slides`" do
       before(:each) do
         capture_output do
           Dir.chdir @tmp_dir do
-            @thor.invoke Keydown::Tasks, "slides", "with_title.md"
+            @thor.invoke Keydown::Tasks, ["slides", "with_title.md"]
             @file = File.new('with_title.html')
             @doc = Nokogiri(@file)
           end
@@ -92,7 +92,7 @@ describe Keydown, "`slides`" do
       before(:each) do
         capture_output do
           Dir.chdir @tmp_dir do
-            @thor.invoke Keydown::Tasks, "slides", "with_title"
+            @thor.invoke Keydown::Tasks, ["slides", "with_title"]
             @file = File.new('with_title.html')
             @doc = Nokogiri(@file)
           end
@@ -109,14 +109,14 @@ describe Keydown, "`slides`" do
       capture_output do
 
       Dir.chdir @tmp_dir do
-        @thor.invoke Keydown::Tasks, "generate", "test"
+        @thor.invoke Keydown::Tasks, ["generate", "test"]
 
         Dir.chdir "test" do
           system "cp #{Keydown::Tasks.source_root}/spec/fixtures/with_title.md #{@tmp_dir}/test/with_title.md"
           system "cp #{Keydown::Tasks.source_root}/spec/fixtures/custom.css #{@tmp_dir}/test/css/custom.css"
           system "cp #{Keydown::Tasks.source_root}/spec/fixtures/custom.js #{@tmp_dir}/test/js/custom.js"
 
-          @thor.invoke Keydown::Tasks, "slides", "with_title.md"
+          @thor.invoke Keydown::Tasks, ["slides", "with_title.md"]
 
           @file = File.new('with_title.html')
           @doc = Nokogiri(@file)
@@ -143,12 +143,12 @@ describe Keydown, "`slides`" do
       capture_output do
 
         Dir.chdir @tmp_dir do
-          @thor.invoke Keydown::Tasks, "generate", "test"
+          @thor.invoke Keydown::Tasks, ["generate", "test"]
 
           Dir.chdir "test" do
             system "cp #{Keydown::Tasks.source_root}/spec/fixtures/with_backgrounds.md #{@tmp_dir}/test/with_backgrounds.md"
 
-            @thor.invoke Keydown::Tasks, "slides", "with_backgrounds.md"
+            @thor.invoke Keydown::Tasks, ["slides", "with_backgrounds.md"]
 
             @file = File.new('with_backgrounds.html')
             @doc = Nokogiri(@file)


### PR DESCRIPTION
Only one actual code change- most changes were in specs, to the way you were calling Thor#invoke

All specs pass under 1.9.2 and 1.8.7
