### PR TITLE
Open slides in browser from console

### DIFF
--- a/keydown.gemspec
+++ b/keydown.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sass'
   s.add_dependency 'compass'
   s.add_dependency 'github-markdown'
+  s.add_dependency 'launchy'
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"

--- a/lib/keydown.rb
+++ b/lib/keydown.rb
@@ -1,6 +1,7 @@
 require 'ostruct'
 require 'digest/sha1'
 require 'tilt'
+require 'launchy'
 
 require 'version'
 require 'keydown/html_helpers'

--- a/lib/keydown/tasks/slides.rb
+++ b/lib/keydown/tasks/slides.rb
@@ -7,7 +7,6 @@ module Keydown
     desc "slides FILE", "Convert a Keydown FILE into an HTML presentation"
 
     def slides(file)
-
       file += '.md' unless file.match(/\.md$/)
 
       unless File.exist?(file)
@@ -36,9 +35,11 @@ module Keydown
 
       presentation = file.gsub('md', 'html')
 
-      create_file presentation, :force => true do
+      output = create_file presentation, :force => true do
         slide_deck.to_html
       end
+      
+      Launchy.open File.join(Dir.pwd, presentation)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,3 +12,9 @@ def capture_output
  ensure
    $stdout = STDOUT
 end
+
+RSpec.configure do |config|
+  config.before(:each) do
+    Launchy.stub(:open)
+  end
+end

--- a/spec/tasks/slides_spec.rb
+++ b/spec/tasks/slides_spec.rb
@@ -19,7 +19,7 @@ describe Keydown, "`slides`" do
   end
 
   let :tmp_dir do
-    "#{Dir.tmpdir}/keydown_test"
+    "#{File.realdirpath(Dir.tmpdir)}/keydown_test"
   end
 
   let :project_dir do
@@ -62,6 +62,16 @@ describe Keydown, "`slides`" do
 
     before :each do
       system "cp -r spec/fixtures/with_title.md #{project_dir}"
+    end
+
+    it "should open resulting html file in the browser" do
+      Launchy.should_receive(:open).with("#{project_dir}/with_title.html")
+
+      capture_output do
+        Dir.chdir project_dir do
+          @thor.invoke Keydown::Tasks, ["slides", "with_title.md"]
+        end
+      end
     end
 
     describe "should generate an html file that" do


### PR DESCRIPTION
I don't like to mess with opening new files from console, so I decided to add Launchy support directly to keydown.
- Add Launchy dependency
- Use Launchy.open to call browser window with the generated presentation
