### PR TITLE
keydown.scss.erb: change ".slide" to "section.slide"

### DIFF
--- a/templates/keydown.scss.erb
+++ b/templates/keydown.scss.erb
@@ -78,12 +78,12 @@ body {
 
   h3 {
     font-size: 3rem;
-  }               
-  
+  }
+
   h4 {
     font-size: 2.25rem;
-  }               
-  
+  }
+
   p, li {
     font-size: 2rem;
   }
@@ -92,7 +92,7 @@ body {
     font-size: .75rem;
   }
 
-  .slide {
+  section.slide {
 
     @include box-vertical-center;
 
@@ -199,7 +199,7 @@ body {
         background: url(../images/cc.large.png) left top no-repeat;
         padding-left: 36px;
        }
-       
+
       a {
        color: #c7c7c7;
       }


### PR DESCRIPTION
This allows use of deck.js's "slide" class on other block elements.

(Upcoming pull request will contain a js plugin to do this automagically.)
