### PR TITLE
Fix the order of CSS files included

### DIFF
--- a/lib/keydown/slidedeck.rb
+++ b/lib/keydown/slidedeck.rb
@@ -21,7 +21,8 @@ module Keydown
     def to_html
       require 'tilt'
 
-      css_files = ['css/keydown.css']
+      css_files = ['css/keydown.css', 'css/default.css',
+                   'css/horizontal-default.css', 'css/swiss.css']
       css_files += Dir.glob('css/*.css')
       css_files.uniq!
 


### PR DESCRIPTION
The css file for the project should be the last CSS file inserted
into the HTML, so that a user can override certain CSS classes.

Fixes #32
